### PR TITLE
Fix issues with GT06 Adapter

### DIFF
--- a/lib/adapters/gt06.js
+++ b/lib/adapters/gt06.js
@@ -22,7 +22,7 @@ var adapter = function (device) {
    return type: login_request, ping, etc.
    *******************************************/
   this.parse_data = function (data) {
-    data = f.bufferToHexString(data);
+    data = data.toString('hex');
     var parts = {
       'start': data.substr(0, 4)
     };

--- a/lib/adapters/gt06.js
+++ b/lib/adapters/gt06.js
@@ -1,5 +1,6 @@
 /* Original code: https://github.com/cnberg/gps-tracking-nodejs/blob/master/lib/adapters/gt06.js */
 f = require('../functions');
+crc = require('crc');
 
 exports.protocol = 'GT06';
 exports.model_name = 'GT06';
@@ -78,7 +79,6 @@ var adapter = function (device) {
 
     this.__count++;
 
-    var crc = require('/usr/lib/node_modules/crc/lib/index.js');
     var crcResult = f.str_pad(crc.crc16(str).toString(16), 4, '0');
 
     var buff = new Buffer('7878' + str + crcResult + '0d0a', 'hex');

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/freshworkstudio/gps-tracking-nodejs",
   "dependencies": {
+    "crc": "^3.5.0",
     "crc16-ccitt-node": "^1.0.4",
     "node.extend": "*"
   }


### PR DESCRIPTION
Just tried the GT06 adapter and it failed with the following errors:

1. Referenced a buffer to hex function no longer available
2. Used a local instance of a npm package

Fixed both in this PR.
